### PR TITLE
Feature/notebook image

### DIFF
--- a/kfdef/kfctl_platiagro_tls.v0.1.0.yaml
+++ b/kfdef/kfctl_platiagro_tls.v0.1.0.yaml
@@ -267,6 +267,8 @@ spec:
         parameters:
           - name: namespace
             value: anonymous
+          - name: image
+            value: platiagro/platiagro-notebook-image:0.1.0
           - name: memory-limits
             value: 4G
           - name: cpu-limits

--- a/kfdef/kfctl_platiagro_tls_gpu.v0.1.0.yaml
+++ b/kfdef/kfctl_platiagro_tls_gpu.v0.1.0.yaml
@@ -21,6 +21,8 @@ spec:
           path: istio/istio-install
       name: istio-install
     - kustomizeConfig:
+        overlays:
+          - https-gateway
         parameters:
           - name: clusterRbacConfig
             value: "OFF"
@@ -76,6 +78,14 @@ spec:
           path: cert-manager/cert-manager
       name: cert-manager
     - kustomizeConfig:
+        parameters:
+          - name: namespace
+            value: istio-system
+        repoRef:
+          name: manifests
+          path: istio/ingressgateway-self-signed-cert
+      name: ingressgateway-self-signed-cert
+    - kustomizeConfig:
         repoRef:
           name: manifests
           path: metacontroller
@@ -119,6 +129,9 @@ spec:
         overlays:
           - istio
           - application
+        parameters:
+        - name: userid-header
+          value: kubeflow-userid
         repoRef:
           name: manifests
           path: jupyter/jupyter-web-app
@@ -127,9 +140,6 @@ spec:
         overlays:
           - istio
           - application
-        parameters:
-        - name: userid-header
-          value: kubeflow-userid
         repoRef:
           name: manifests
           path: jupyter/notebook-controller
@@ -258,7 +268,7 @@ spec:
           - name: namespace
             value: anonymous
           - name: image
-            value: platiagro/platiagro-notebook-image:0.1.0
+            value: platiagro/platiagro-notebook-image-gpu:0.1.0
           - name: memory-limits
             value: 4G
           - name: cpu-limits

--- a/platiagro/notebook/base/kustomization.yaml
+++ b/platiagro/notebook/base/kustomization.yaml
@@ -16,6 +16,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
+- name: image
+  objref:
+    kind: ConfigMap
+    name: platiagro-notebook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.image
 - name: memory-limits
   objref:
     kind: ConfigMap

--- a/platiagro/notebook/base/notebook.yaml
+++ b/platiagro/notebook/base/notebook.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     spec:
       containers:
-      - image: platiagro/platiagro-notebook-image:0.1.0
+      - image: "$(image)"
         name: server
         resources:
           requests:

--- a/platiagro/notebook/base/params.env
+++ b/platiagro/notebook/base/params.env
@@ -1,3 +1,4 @@
 namespace=anonymous
+image=platiagro/platiagro-notebook-image:0.1.0
 memory-limits=4G
 cpu-limits=2

--- a/platiagro/notebook/base/params.yaml
+++ b/platiagro/notebook/base/params.yaml
@@ -1,4 +1,6 @@
 varReference:
+- path: spec/template/spec/containers/image
+  kind: Notebook
 - path: spec/template/spec/containers/resources/limits/cpu
   kind: Notebook
 - path: spec/template/spec/containers/resources/limits/memory

--- a/platiagro/pipelines/base/deployment.yaml
+++ b/platiagro/pipelines/base/deployment.yaml
@@ -29,6 +29,16 @@ spec:
               value: "platiagro"
             - name: JUPYTER_ENDPOINT
               value: "http://server.anonymous:80/notebook/anonymous/server"
+            - name: KF_PIPELINES_NAMESPACE
+              value: deployments
+            - name: MEMORY_REQUEST
+              value: 2G
+            - name: CPU_REQUEST
+              value: 500m
+            - name: MEMORY_LIMIT
+              value: 4G
+            - name: CPU_LIMIT
+              value: 2000m
           ports:
             - containerPort: 8080
           livenessProbe:


### PR DESCRIPTION
Makes notebook image configurable …
Uses kfdef parameters to inform the image to platiagro/notebook.
This will allow custom image configuration for GPU.

Adds a custom configuration file for GPU environments …
Sets platiagro/platiagro-notebook-image-gpu:0.1.0 as default docker image
for kfdef/kfctl_platiagro_tls_gpu.v0.1.0.yaml.