### PR TITLE
Fix wrong DBConfig on pipelines/apiservice

### DIFF
--- a/pipeline/api-service/base/config-map.yaml
+++ b/pipeline/api-service/base/config-map.yaml
@@ -6,7 +6,8 @@ data:
   config.json: |
     {
       "DBConfig": {
-        "DriverName": "mysql.kubeflow",
+        "Host": "mysql.kubeflow",
+        "DriverName": "mysql",
         "DataSourceName": "",
         "DBName": "mlpipeline",
         "GroupConcatMaxLen": "4194304"


### PR DESCRIPTION
Sets correct values:
"Host": "mysql.kubeflow"
"DriverName": "mysql"
